### PR TITLE
GET /utxos/:address & /fees endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.db
+regtest-server

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repo contains a Go implementation of a web server exposing the following endpoints to interact with the underline cluster of bitcoin daemons in regtest mode:
 
-* `send/:address` sends funds to the target address
-* `broadcast/:tx` publishes the passed raw tx to the regtest network
+* `send/:address` sends funds to the target address and returns the transaction hash
+* `broadcast/:tx` publishes the passed raw tx to the regtest network and returns the transaction hash
 * `utxos/:address` returns all **unspent** transaction output related to the target address [WIP]
 
 It uses [bitcoin-testnet-box](https://github.com/freewil/bitcoin-testnet-box/) with [Docker](https://docker.io) to start the daemons.
@@ -52,3 +52,5 @@ make stop
 make clean
 exit
 ```
+
+## Endpoint responses

--- a/main.go
+++ b/main.go
@@ -19,6 +19,12 @@ func main() {
 	}
 	defer client.Shutdown()
 
+	// Mine some blocks to enable faucet service
+	_, err = client.Mine(200)
+	if err != nil {
+		log.Println("Warning: an error occured when mining blocks, please check the following error and manually mine at least 100 blocks to enable faucet service.\n", err)
+	}
+
 	r := router.New(client)
 
 	log.Println("Starting server at " + config.Address + ":" + config.Port)

--- a/router/database.go
+++ b/router/database.go
@@ -1,0 +1,133 @@
+package router
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+type Database struct {
+	DB *bolt.DB
+}
+
+// New creates or opens a db
+func (bb *Database) New() error {
+	db, err := bolt.Open("Utxos.db", 0600, &bolt.Options{Timeout: 10 * time.Second})
+	if err != nil {
+		return err
+	}
+
+	bb.DB = db
+
+	return nil
+}
+
+// Update writes
+func (bb *Database) Update(addrBucket string, txBucket string, utxoBucket string, key string, value string) error {
+	log.Println("********************")
+	log.Println("ADDING NEW ENTRY IN DATABASE:")
+	log.Println("Address bucket:", addrBucket)
+	log.Println("Tx bucket:", txBucket)
+	log.Println("Utxo bucket:", utxoBucket)
+	log.Println("Key:", key)
+	log.Println("Value:", value)
+
+	return bb.DB.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(addrBucket))
+		if err != nil {
+			return err
+		}
+		sb, err := b.CreateBucketIfNotExists([]byte(txBucket))
+		if err != nil {
+			return err
+		}
+		ssb, err := sb.CreateBucketIfNotExists([]byte(utxoBucket))
+		if err != nil {
+			return err
+		}
+
+		err = ssb.Put([]byte(key), []byte(value))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// Get retrieves an entry from the bucket
+func (bb *Database) Get(addrBucket string, txBucket string, utxoBucket string, key string) (string, error) {
+	var response string
+	err := bb.DB.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(addrBucket))
+		if b == nil {
+			return fmt.Errorf("Bucket %s not found", addrBucket)
+		}
+		sb := b.Bucket([]byte(txBucket))
+		if sb == nil {
+			return fmt.Errorf("Bucket %s not found", txBucket)
+		}
+		ssb := sb.Bucket([]byte(utxoBucket))
+		if ssb == nil {
+			return fmt.Errorf("Bucket %s not found", utxoBucket)
+		}
+		response = string(ssb.Get([]byte(key)))
+
+		return nil
+	})
+
+	return response, err
+}
+
+// List retrieves all data in a bucket
+func (bb *Database) List(addrBucket string, txBucket string) ([][]byte, error) {
+	var response [][]byte
+	err := bb.DB.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(addrBucket))
+		if b == nil {
+			return fmt.Errorf("Bucket %s not found", addrBucket)
+		}
+		sb := b.Bucket([]byte(txBucket))
+		if sb == nil {
+			return fmt.Errorf("Bucket %s not found", txBucket)
+		}
+
+		c := sb.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			ssb := sb.Bucket(k)
+			ssb.ForEach(func(_, value []byte) error {
+				response = append(response, value)
+				return nil
+			})
+		}
+
+		return nil
+	})
+
+	return response, err
+}
+
+// Delete an entry from the bucket
+func (bb *Database) Delete(addrBucket string, txBucket string, utxoBucket string, key string) error {
+	return bb.DB.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(addrBucket))
+		if b == nil {
+			return fmt.Errorf("Bucket %s not found", addrBucket)
+		}
+		sb := b.Bucket([]byte(txBucket))
+		if sb == nil {
+			return fmt.Errorf("Bucket %s not found", txBucket)
+		}
+		ssb := sb.Bucket([]byte(utxoBucket))
+		if ssb == nil {
+			return fmt.Errorf("Bucket %s not found", utxoBucket)
+		}
+		return ssb.Delete([]byte(key))
+	})
+}
+
+// Close ends connection to the db
+func (bb *Database) Close() error {
+	return bb.DB.Close()
+}

--- a/router/http_util.go
+++ b/router/http_util.go
@@ -1,0 +1,37 @@
+package router
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var client = &http.Client{Timeout: 10 * time.Second}
+
+func httpPOST(url string, bodyString string, header map[string]string) (int, string, error) {
+
+	body := strings.NewReader(bodyString)
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return 0, "", err
+	}
+
+	for key, value := range header {
+		req.Header.Set(key, value)
+	}
+
+	rs, err := client.Do(req)
+	if err != nil {
+		return 0, "", errors.New("Failed to create named key request: " + err.Error())
+	}
+	defer rs.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(rs.Body)
+	if err != nil {
+		return 0, "", errors.New("Failed to parse response body: " + err.Error())
+	}
+
+	return rs.StatusCode, string(bodyBytes), nil
+}

--- a/router/regtest.go
+++ b/router/regtest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -20,6 +21,12 @@ import (
 
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcutil"
+)
+
+const (
+	host     = "localhost:19001"
+	user     = "admin1"
+	password = "123"
 )
 
 // RegTest handles communication with both the regtest daemon and the local database
@@ -37,9 +44,9 @@ func (r *RegTest) New() error {
 	connConfig := &rpcclient.ConnConfig{
 		HTTPPostMode: true,
 		DisableTLS:   true,
-		Host:         "localhost:19001",
-		User:         "admin1",
-		Pass:         "123",
+		Host:         host,
+		User:         user,
+		Pass:         password,
 	}
 
 	client, err := rpcclient.New(connConfig, nil)
@@ -69,12 +76,16 @@ func (r *RegTest) Shutdown() {
 	r.DB.Close()
 }
 
+type txResponse struct {
+	TxHash string `json:"tx_hash"`
+}
+
 // SendTo sends 1 btc to the given address from the miner account (faucet service)
 // Here the db is updated adding the new utxo to the "unpent" bucket
 func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
 	// send request through regtest client
 	address := mux.Vars(req)["address"]
-	txHash, err := sendTo(r, address)
+	txHash, blockHash, err := sendTo(r, address)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -82,7 +93,7 @@ func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
 
 	// from the transaction we retrieve the hash of the utxo by double_hash(txHash + outputTxIndex)
 	// this hash is used as the id of the utxo in the db, the value is the stringified json representation of the utxo
-	key, value, err := prepareUtxo(r, txHash, address)
+	key, value, err := prepareUtxo(r, txHash, address, blockHash)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -93,7 +104,7 @@ func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	resp := fmt.Sprintf(`{"txHash": "%s"}`, txHash.String())
+	resp := txResponse{txHash.String()}
 	json.NewEncoder(w).Encode(resp)
 }
 
@@ -109,7 +120,7 @@ func (r *RegTest) Broadcast(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	txHash, err := broadcast(r, rawTx)
+	txHash, blockHash, err := broadcast(r, rawTx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -141,7 +152,7 @@ func (r *RegTest) Broadcast(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// handle outputs
-	addresses, keys, values, err := getOutputsFromTx(r, txHash)
+	addresses, keys, values, err := getOutputsFromTx(r, txHash, blockHash)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -155,7 +166,7 @@ func (r *RegTest) Broadcast(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	resp := fmt.Sprintf(`{"txHash": "%s"}`, txHash.String())
+	resp := txResponse{txHash.String()}
 	json.NewEncoder(w).Encode(resp)
 }
 
@@ -168,9 +179,9 @@ func (r *RegTest) GetUtxos(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	list := []*btcjson.Vout{}
+	list := []*utxo{}
 	for _, raw := range rawList {
-		vout := &btcjson.Vout{}
+		vout := &utxo{}
 		err := json.Unmarshal(raw, vout)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -179,50 +190,92 @@ func (r *RegTest) GetUtxos(w http.ResponseWriter, req *http.Request) {
 		list = append(list, vout)
 	}
 
-	resp, _ := json.Marshal(list)
-	json.NewEncoder(w).Encode(string(resp))
+	json.NewEncoder(w).Encode(list)
+}
+
+// EstimateFees queries the blockchain to get the min relay fee per KB
+func (r *RegTest) EstimateFees(w http.ResponseWriter, req *http.Request) {
+	fees, err := estimateFees()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(fees)
 }
 
 func mine(r *RegTest, num int) ([]*chainhash.Hash, error) {
 	return r.Client.Generate(uint32(num))
 }
 
-func sendTo(r *RegTest, address string) (*chainhash.Hash, error) {
+func sendTo(r *RegTest, address string) (*chainhash.Hash, *chainhash.Hash, error) {
 	receiver, err := btcutil.DecodeAddress(address, &chaincfg.RegressionNetParams)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	txHash, err := r.Client.SendToAddress(receiver, btcutil.Amount(100000000))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	_, err = mine(r, 1)
+	blockHash, err := mine(r, 1)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return txHash, nil
+	return txHash, blockHash[0], nil
 }
 
-func broadcast(r *RegTest, tx []byte) (*chainhash.Hash, error) {
+func broadcast(r *RegTest, tx []byte) (*chainhash.Hash, *chainhash.Hash, error) {
 	rawTx := &wire.MsgTx{}
 	err := rawTx.Deserialize(bytes.NewReader(tx))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	txHash, err := r.Client.SendRawTransaction(rawTx, true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	_, err = mine(r, 1)
+	blockHash, err := mine(r, 1)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return txHash, blockHash[0], nil
+}
+
+type estimateFeeResponse struct {
+	High   int `json:"high_fee_per_kb"`
+	Medium int `json:"medium_fee_per_kb"`
+	Low    int `json:"low_fee_per_kb"`
+}
+
+// estimateFees makes an HTTP API call to the regtest deamon without using the RegTest client.
+// This is because in the actual implementation of rpcclient does not support the `getnetworkinfo` method,
+// where `relayFee` can be found. More on this can be found here http://chainquery.com/bitcoin-api/getnetworkinfo
+func estimateFees() (*estimateFeeResponse, error) {
+	url, headers, body := getEstimationRequestParams()
+
+	statusCode, resp, err := httpPOST(url, body, headers)
 	if err != nil {
 		return nil, err
 	}
+	if statusCode != 200 {
+		return nil, fmt.Errorf("An unexpected error occured while estimating fees, check the response: %s", resp)
+	}
 
-	return txHash, nil
+	type response struct {
+		Result struct {
+			Fee float64 `json:"relayFee"`
+		} `json:"result"`
+	}
+	out := &response{}
+	json.Unmarshal([]byte(resp), out)
+
+	fee := int(out.Result.Fee * math.Pow10(8))
+	return &estimateFeeResponse{fee, fee, fee}, nil
 }
 
 // decodeTx takes a tx hash and returns the decoded tx object
@@ -241,24 +294,25 @@ func decodeTx(r *RegTest, txHash *chainhash.Hash) (*btcjson.TxRawResult, error) 
 	return r.Client.DecodeRawTransaction(buf.Bytes())
 }
 
-// prepareUtxo takes a tx object, finds the utxo "sent" to the given address and returns the
-// key,value pair to be saved in the db
-func prepareUtxo(r *RegTest, txHash *chainhash.Hash, address string) (string, string, error) {
+// prepareUtxo takes a tx object, finds the utxo of to the given address in the tx outputs
+//  and returns the key/value pair to be saved in the db
+func prepareUtxo(r *RegTest, txHash *chainhash.Hash, address string, blockHash *chainhash.Hash) (string, string, error) {
 	txObject, err := decodeTx(r, txHash)
 	if err != nil {
 		return "", "", err
 	}
 
 	var key string
-	vout := []byte{}
+	var value string
 	for _, v := range txObject.Vout {
 		if v.ScriptPubKey.Addresses[0] == address {
 			key = getUtxoKey(txHash.String(), int(v.N))
-			vout, _ = json.Marshal(v)
+			vout, _ := marshalUtxo(v, txHash.String(), blockHash.String())
+			value = string(vout)
 		}
 	}
 
-	return key, string(vout), nil
+	return key, value, nil
 }
 
 // getInputsFromTx reconstructs the tx object from the hash and then, for each input:
@@ -275,15 +329,15 @@ func getInputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, []
 	keys := []string{}
 	addresses := []string{}
 	txHashes := []string{}
-	for _, vin := range txObject.Vin {
-		k := getUtxoKey(vin.Txid, int(vin.Vout))
-		inputTxHash, _ := chainhash.NewHashFromStr(vin.Txid)
-		tx, _ := decodeTx(r, inputTxHash)
-		address, _ := getAddressFromUtxo(tx, vin.Vout)
+	for _, v := range txObject.Vin {
+		key := getUtxoKey(v.Txid, int(v.Vout))
+		txHash, _ := chainhash.NewHashFromStr(v.Txid)
+		tx, _ := decodeTx(r, txHash)
+		address, _ := getAddressFromUtxo(tx, v.Vout)
 
-		keys = append(keys, k)
+		keys = append(keys, key)
 		addresses = append(addresses, address)
-		txHashes = append(txHashes, vin.Txid)
+		txHashes = append(txHashes, v.Txid)
 	}
 
 	return addresses, keys, txHashes, nil
@@ -294,7 +348,7 @@ func getInputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, []
 // - calculates the utxo id (key)
 // - stringifies the entire utxo JSON object (value)
 // This returns 3 arrays of addresses, keys and values, or an error
-func getOutputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, []string, error) {
+func getOutputsFromTx(r *RegTest, txHash *chainhash.Hash, blockHash *chainhash.Hash) ([]string, []string, []string, error) {
 	txObject, err := decodeTx(r, txHash)
 	if err != nil {
 		return nil, nil, nil, err
@@ -304,13 +358,15 @@ func getOutputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, [
 	values := []string{}
 	addresses := []string{}
 	for _, vout := range txObject.Vout {
-		k := getUtxoKey(txHash.String(), int(vout.N))
-		addr := vout.ScriptPubKey.Addresses[0]
-		v, _ := json.Marshal(vout)
+		if vout.Value > 0 {
+			address := vout.ScriptPubKey.Addresses[0]
+			key := getUtxoKey(txHash.String(), int(vout.N))
+			value, _ := marshalUtxo(vout, txHash.String(), blockHash.String())
 
-		keys = append(keys, k)
-		values = append(values, string(v))
-		addresses = append(addresses, addr)
+			addresses = append(addresses, address)
+			keys = append(keys, key)
+			values = append(values, string(value))
+		}
 	}
 
 	return addresses, keys, values, nil
@@ -336,4 +392,26 @@ func getAddressFromUtxo(tx *btcjson.TxRawResult, nout uint32) (string, error) {
 	}
 
 	return "", errors.New("Error while getting utxo: Address not found")
+}
+
+type utxo struct {
+	Index        uint32 `json:"index"`
+	Value        uint32 `json:"value"`
+	ScriptPubKey string `json:"script_pubkey"`
+	Hash         string `json:"hash"`
+	BlockHash    string `json:"block_hash"`
+}
+
+func marshalUtxo(v btcjson.Vout, hash string, blockHash string) ([]byte, error) {
+	satoshis := uint32(v.Value * math.Pow10(8))
+	c := utxo{v.N, satoshis, v.ScriptPubKey.Hex, hash, blockHash}
+	return json.Marshal(c)
+}
+
+func getEstimationRequestParams() (string, map[string]string, string) {
+	url := fmt.Sprintf("http://%s:%s@%s", user, password, host)
+	header := map[string]string{"Content-Type": "application/json"}
+	body := `{"jsonrpc": "1.0", "id": "2", "method": "getnetworkinfo", "params": []}`
+
+	return url, header, body
 }

--- a/router/regtest.go
+++ b/router/regtest.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
+	"strconv"
+
+	"github.com/btcsuite/btcd/btcjson"
 
 	"github.com/btcsuite/btcd/wire"
 
@@ -19,13 +22,18 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
+// RegTest handles communication with both the regtest daemon and the local database
+// @param Client <*Client>: handles remote API calls to the regtest daemon
+// @param DB <*Database>: BBolt database is used to keep track of the utxos.
+// 												This handles read/write/list/delete operations to the db
 type RegTest struct {
-	Client        *rpcclient.Client
-	FaucetAccount string
+	Client *rpcclient.Client
+	DB     *Database
 }
 
 // New configures and creates a Client instance
 func (r *RegTest) New() error {
+	// Configure regtest client to connect the daemon
 	connConfig := &rpcclient.ConnConfig{
 		HTTPPostMode: true,
 		DisableTLS:   true,
@@ -38,14 +46,18 @@ func (r *RegTest) New() error {
 	if err != nil {
 		return err
 	}
-	addr, err := client.GetAccountAddress("wallet.dat")
+
+	// Setup db
+	db := &Database{}
+	err = db.New()
 	if err != nil {
 		return err
 	}
 
 	r.Client = client
-	r.FaucetAccount = addr.String()
+	r.DB = db
 
+	// Since regtest chain should be empty at this point, lets mine some blocks to increase miner balance
 	mine(r, 200)
 
 	return nil
@@ -54,10 +66,13 @@ func (r *RegTest) New() error {
 // Shutdown disconnect from rpc server and stop all goroutines
 func (r *RegTest) Shutdown() {
 	r.Client.Shutdown()
+	r.DB.Close()
 }
 
-// SendTo sends 1 btc to the given address from the faucet account
+// SendTo sends 1 btc to the given address from the miner account (faucet service)
+// Here the db is updated adding the new utxo to the "unpent" bucket
 func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
+	// send request through regtest client
 	address := mux.Vars(req)["address"]
 	txHash, err := sendTo(r, address)
 	if err != nil {
@@ -65,13 +80,27 @@ func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO save tx in db
+	// from the transaction we retrieve the hash of the utxo by double_hash(txHash + outputTxIndex)
+	// this hash is used as the id of the utxo in the db, the value is the stringified json representation of the utxo
+	key, value, err := prepareUtxo(r, txHash, address)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	err = r.DB.Update(address, "unspent", txHash.String(), key, value)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-	resp := fmt.Sprintf(`{"txHash": %s}`, txHash.String())
+	resp := fmt.Sprintf(`{"txHash": "%s"}`, txHash.String())
 	json.NewEncoder(w).Encode(resp)
 }
 
 // Broadcast publishes a raw transaction to the network
+// Here we need to do things both for tx inputs and outputs:
+// - for each input, move the corresponding entry from the "unpent" bucket to the "spent" one
+// - for each output, create an entry in the "unspent" bucket
 func (r *RegTest) Broadcast(w http.ResponseWriter, req *http.Request) {
 	tx := mux.Vars(req)["tx"]
 	rawTx, err := hex.DecodeString(tx)
@@ -85,10 +114,73 @@ func (r *RegTest) Broadcast(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// TODO: save tx in db && update spent utxos
 
-	resp := fmt.Sprintf(`{"txHash": %s}`, txHash.String())
+	// handle inputs
+	addresses, keys, txHashes, err := getInputsFromTx(r, txHash)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	for i, k := range keys {
+		v, err := r.DB.Get(addresses[i], "unspent", txHashes[i], k)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = r.DB.Delete(addresses[i], "unspent", txHashes[i], k)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = r.DB.Update(addresses[i], "spent", txHashes[i], k, v)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// handle outputs
+	addresses, keys, values, err := getOutputsFromTx(r, txHash)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	for i, k := range keys {
+		err = r.DB.Update(addresses[i], "unspent", txHash.String(), k, values[i])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	resp := fmt.Sprintf(`{"txHash": "%s"}`, txHash.String())
 	json.NewEncoder(w).Encode(resp)
+}
+
+// GetUtxos returns the list of unpsent tx output for a given address
+func (r *RegTest) GetUtxos(w http.ResponseWriter, req *http.Request) {
+	address := mux.Vars(req)["address"]
+	rawList, err := r.DB.List(address, "unspent")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	list := []*btcjson.Vout{}
+	for _, raw := range rawList {
+		vout := &btcjson.Vout{}
+		err := json.Unmarshal(raw, vout)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		list = append(list, vout)
+	}
+
+	resp, _ := json.Marshal(list)
+	json.NewEncoder(w).Encode(string(resp))
 }
 
 func mine(r *RegTest, num int) ([]*chainhash.Hash, error) {
@@ -122,7 +214,6 @@ func broadcast(r *RegTest, tx []byte) (*chainhash.Hash, error) {
 
 	txHash, err := r.Client.SendRawTransaction(rawTx, true)
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
 
@@ -132,4 +223,117 @@ func broadcast(r *RegTest, tx []byte) (*chainhash.Hash, error) {
 	}
 
 	return txHash, nil
+}
+
+// decodeTx takes a tx hash and returns the decoded tx object
+func decodeTx(r *RegTest, txHash *chainhash.Hash) (*btcjson.TxRawResult, error) {
+	rawTx, err := r.Client.GetRawTransaction(txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err = rawTx.MsgTx().Serialize(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Client.DecodeRawTransaction(buf.Bytes())
+}
+
+// prepareUtxo takes a tx object, finds the utxo "sent" to the given address and returns the
+// key,value pair to be saved in the db
+func prepareUtxo(r *RegTest, txHash *chainhash.Hash, address string) (string, string, error) {
+	txObject, err := decodeTx(r, txHash)
+	if err != nil {
+		return "", "", err
+	}
+
+	var key string
+	vout := []byte{}
+	for _, v := range txObject.Vout {
+		if v.ScriptPubKey.Addresses[0] == address {
+			key = getUtxoKey(txHash.String(), int(v.N))
+			vout, _ = json.Marshal(v)
+		}
+	}
+
+	return key, string(vout), nil
+}
+
+// getInputsFromTx reconstructs the tx object from the hash and then, for each input:
+// - gets the address who owns the input
+// - calculates the utxo id used in the database (key)
+// - gets the input tx hash
+// this functions returns 3 arrays containg input addresses, keys and txHashes, or an error
+func getInputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, []string, error) {
+	txObject, err := decodeTx(r, txHash)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	keys := []string{}
+	addresses := []string{}
+	txHashes := []string{}
+	for _, vin := range txObject.Vin {
+		k := getUtxoKey(vin.Txid, int(vin.Vout))
+		inputTxHash, _ := chainhash.NewHashFromStr(vin.Txid)
+		tx, _ := decodeTx(r, inputTxHash)
+		address, _ := getAddressFromUtxo(tx, vin.Vout)
+
+		keys = append(keys, k)
+		addresses = append(addresses, address)
+		txHashes = append(txHashes, vin.Txid)
+	}
+
+	return addresses, keys, txHashes, nil
+}
+
+// getOutpytsFromTx similarly to the above function deserializes the tx from the hash and for each output:
+// - gets the receiving address
+// - calculates the utxo id (key)
+// - stringifies the entire utxo JSON object (value)
+// This returns 3 arrays of addresses, keys and values, or an error
+func getOutputsFromTx(r *RegTest, txHash *chainhash.Hash) ([]string, []string, []string, error) {
+	txObject, err := decodeTx(r, txHash)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	keys := []string{}
+	values := []string{}
+	addresses := []string{}
+	for _, vout := range txObject.Vout {
+		k := getUtxoKey(txHash.String(), int(vout.N))
+		addr := vout.ScriptPubKey.Addresses[0]
+		v, _ := json.Marshal(vout)
+
+		keys = append(keys, k)
+		values = append(values, string(v))
+		addresses = append(addresses, addr)
+	}
+
+	return addresses, keys, values, nil
+}
+
+// getUtxoKey calculates the double_hash(utxoTxHash + string(utxoTxIndex * 100))
+// This hash is used as the utxo unique identifier in the database
+func getUtxoKey(hash string, nout int) string {
+	message, _ := hex.DecodeString(hash + strconv.Itoa(nout*100))
+	return hex.EncodeToString(chainhash.DoubleHashB(message))
+}
+
+// getAddressFromUtxo returns the address that is the receiver for the NOUTth output of the given transaction
+func getAddressFromUtxo(tx *btcjson.TxRawResult, nout uint32) (string, error) {
+	if utxo := tx.Vout[nout]; utxo.N == nout {
+		return utxo.ScriptPubKey.Addresses[0], nil
+	}
+
+	for _, utxo := range tx.Vout {
+		if utxo.N == nout {
+			return utxo.ScriptPubKey.Addresses[0], nil
+		}
+	}
+
+	return "", errors.New("Error while getting utxo: Address not found")
 }

--- a/router/router.go
+++ b/router/router.go
@@ -18,6 +18,7 @@ func New(client *RegTest) *Router {
 	r.HandleFunc("/send/{address}", r.RegTestClient.SendTo)
 	r.HandleFunc("/broadcast/{tx}", r.RegTestClient.Broadcast)
 	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos)
+	r.HandleFunc("/fees", r.RegTestClient.EstimateFees)
 
 	return r
 }

--- a/router/router.go
+++ b/router/router.go
@@ -17,6 +17,7 @@ func New(client *RegTest) *Router {
 
 	r.HandleFunc("/send/{address}", r.RegTestClient.SendTo)
 	r.HandleFunc("/broadcast/{tx}", r.RegTestClient.Broadcast)
+	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos)
 
 	return r
 }


### PR DESCRIPTION
This adds a BBolt database to keep track of utxos and an endpoint to get utxos from an address.
The database is designed with 3 nested buckets:
- Top-level bucket is named with the btc address
- The mid-level bucket is named `spent`|`unspent`
- The low-level bucket is named with the tx hash of the utxo to be saved

The low-level bucket contains key/value pairs that are respectevely:
- the `double_hash(utxoTxHash + string(utxoTxIndex * 100))`
- the stringified JSON object version of the utxo

When calling `send/:address` endpoint the utxo created owned by `address` is saved in the respective `unspent` bucket
When calling `broadcast/:tx` endpoint the tx inputs are moved from each `unspent`to `spent` bucket, the outputs are added to `unspent`.

In this way we do not need to search sequentially for an utxo saved in the db

This also adds an endpoint `/fees` to estimate fees.  
It returns an object with high, medium and low fees per kb all set to the min relay fee that can be retrieved by quering the deamon with the `getnetworkinfo` method.  
Unfortunately the `btcd/rpcclient` package used does not support this method because it implements the original `bitcoin-cli` ones. This is solved by making an HTTP API call using the `net/http` package like:
```
curl \
-X POST \
-H "Contet-Type: application/json" \
-d '{"jsonrpc":"1.0", "id":"1", "method": "getnetworkinfo","params":[]}' \
http://admin1:123@localhost:19001/
```