### PR TITLE
add GET /ping endpoint for health checking

### DIFF
--- a/router/regtest.go
+++ b/router/regtest.go
@@ -82,6 +82,17 @@ func (r *RegTest) Mine(num int) ([]*chainhash.Hash, error) {
 	return r.Client.Generate(uint32(num))
 }
 
+// Ping is used as health check endpoint
+func (r *RegTest) Ping(w http.ResponseWriter, req *http.Request) {
+	resp, err := ping(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(resp)
+}
+
 // SendTo sends 1 btc to the given address from the miner account (faucet service)
 // Here the db is updated adding the new utxo to the "unpent" bucket
 func (r *RegTest) SendTo(w http.ResponseWriter, req *http.Request) {
@@ -204,6 +215,10 @@ func (r *RegTest) EstimateFees(w http.ResponseWriter, req *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(fees)
+}
+
+func ping(r *RegTest) (*btcjson.GetBlockChainInfoResult, error) {
+	return r.Client.GetBlockChainInfo()
 }
 
 func sendTo(r *RegTest, address string) (*chainhash.Hash, *chainhash.Hash, error) {

--- a/router/router.go
+++ b/router/router.go
@@ -19,6 +19,7 @@ func New(client *RegTest) *Router {
 	r.HandleFunc("/broadcast/{tx}", r.RegTestClient.Broadcast)
 	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos)
 	r.HandleFunc("/fees", r.RegTestClient.EstimateFees)
+	r.HandleFunc("/ping", r.RegTestClient.Ping)
 
 	return r
 }


### PR DESCRIPTION
This endpoint returns the response of the `getblockchaininfo` JSON-RPC call.
Some other service, `vault-server` for example, could be able to check for the `regtest-server` availability before trying to make any other API call.

Response example:
```
{
  "chain": "regtest",
  "blocks": 200,
  "headers": 200,
  "bestblockhash": "3c97b3ec81f1148e52152aaca3dff03cfc78aa083e19aecb89bd5e75dad98c4f",
  "difficulty": 4.656542373906925e-10,
  "mediantime": 1544021932,
  "verificationprogress": 1,
  "pruned": false,
  "chainwork": "0000000000000000000000000000000000000000000000000000000000000192",
  "softforks": [
    {
      "id": "bip34",
      "version": 2,
      "reject": {
        "status": false
      }
    },
    {
      "id": "bip66",
      "version": 3,
      "reject": {
        "status": false
      }
    },
    {
      "id": "bip65",
      "version": 4,
      "reject": {
        "status": false
      }
    }
  ],
  "bip9_softforks": {
    "csv": {
      "status": "started",
      "bit": 0,
      "startTime": 0,
      "timeout": 9223372036854776000,
      "since": 144
    },
    "segwit": {
      "status": "active",
      "bit": 0,
      "startTime": -1,
      "timeout": 9223372036854776000,
      "since": 0
    }
  }
}
```