### PR TITLE
remove mining blocks at start time && add /endpoint to get transaction object by hash

### DIFF
--- a/regtest/main.go
+++ b/regtest/main.go
@@ -19,12 +19,6 @@ func main() {
 	}
 	defer client.Shutdown()
 
-	// Mine some blocks to enable faucet service
-	_, err = client.Mine(200)
-	if err != nil {
-		log.Println("Warning: an error occured when mining blocks, please check the following error and manually mine at least 100 blocks to enable faucet service.\n", err)
-	}
-
 	r := router.New(client)
 
 	log.Println("Starting server at " + config.Address + ":" + config.Port)

--- a/regtest/router/router.go
+++ b/regtest/router/router.go
@@ -20,6 +20,7 @@ func New(client *RegTest) *Router {
 	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos)
 	r.HandleFunc("/fees", r.RegTestClient.EstimateFees)
 	r.HandleFunc("/ping", r.RegTestClient.Ping)
+	r.HandleFunc("/txs/{hash}", r.RegTestClient.GetTx)
 
 	return r
 }

--- a/regtest/router/router.go
+++ b/regtest/router/router.go
@@ -15,12 +15,12 @@ func New(client *RegTest) *Router {
 
 	r := &Router{router, client}
 
-	r.HandleFunc("/send/{address}", r.RegTestClient.SendTo)
-	r.HandleFunc("/broadcast/{tx}", r.RegTestClient.Broadcast)
-	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos)
-	r.HandleFunc("/fees", r.RegTestClient.EstimateFees)
-	r.HandleFunc("/ping", r.RegTestClient.Ping)
-	r.HandleFunc("/txs/{hash}", r.RegTestClient.GetTx)
+	r.HandleFunc("/send", r.RegTestClient.SendTo).Methods("POST")
+	r.HandleFunc("/broadcast", r.RegTestClient.Broadcast).Methods("POST")
+	r.HandleFunc("/utxos/{address}", r.RegTestClient.GetUtxos).Methods("GET")
+	r.HandleFunc("/fees", r.RegTestClient.EstimateFees).Methods("GET")
+	r.HandleFunc("/ping", r.RegTestClient.Ping).Methods("GET")
+	r.HandleFunc("/txs/{hash}", r.RegTestClient.GetTx).Methods("GET")
 
 	return r
 }


### PR DESCRIPTION
@tiero 
This closes #7
Also, mining 200 blocks at start time has been removed since it is done automatically by `systemd` after starting `regtest-cluser-daemon` at boot. 